### PR TITLE
Fix dependency to match the one before #4.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ long_description = read('README.rst') + '\n\n' + read('CHANGES.rst')
 
 ZCML_REQUIRES = [
     'zope.component[zcml]',
-    'zope.securitypolicy[zcml] >= 3.8',
+    'zope.security[zcml] >= 3.8',
 ]
 
 TESTS_REQUIRE = ZCML_REQUIRES + [


### PR DESCRIPTION
In #4 the zcml dependency was changed from zope.security[zcml] to zope.securitypolicy[zcml].
But the latter one does not have a zcml extra, so this change does not seem to be intensional.