### PR TITLE
Fix test compatibility with zope.i18n 4.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
 
 - Add ``.git`` to the list of directory names that are ignored by default.
 
+- Fix test compatibility with zope.i18n 4.3.
+  See https://github.com/zopefoundation/zope.browserresource/issues/8
 
 4.2.1 (2017-09-01)
 ==================


### PR DESCRIPTION
Fixes #8

Also fix whitespace warnings in test_i18nfile.py and remove unneeded use of test_suite (since we're not importing TestI18NAware anymore).