### PR TITLE
only execute the IETag adapter configuration when used in non Zope2 c…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,10 @@
 ================
 
 - Add support for Python 3.8.
-- We decided to make the registration of the IETag adapter conditional on the environment (not Zope2)
-  because Products.Five register this Adapter explicit.
+
+- Make the registration of the ``FileETag`` adapter conditional on the environment
+  as Zope registers this adapter explicitly in ``Products.Five.browser``.
+  See `#12 <https://github.com/zopefoundation/zope.browserresource/pull/12>`_.
 
 
 4.3 (2018-10-05)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@
 ================
 
 - Add support for Python 3.8.
+- We decided to make the registration of the IETag adapter conditional on the environment (not Zope2)
+  because Products.Five register this Adapter explicit.
 
 
 4.3 (2018-10-05)

--- a/src/zope/browserresource/configure.zcml
+++ b/src/zope/browserresource/configure.zcml
@@ -5,7 +5,7 @@
   <include file="meta.zcml" package="zope.security" />
 
   <adapter factory=".resource.AbsoluteURL" />
-  <adapter factory=".file.FileETag" zcml:condition="not-installed Zope2"/>
+  <adapter factory=".file.FileETag" zcml:condition="not-installed Zope"/>
 
   <view
       for="zope.component.interfaces.ISite"

--- a/src/zope/browserresource/configure.zcml
+++ b/src/zope/browserresource/configure.zcml
@@ -1,10 +1,11 @@
-<configure xmlns="http://namespaces.zope.org/zope">
+<configure xmlns="http://namespaces.zope.org/zope"
+           xmlns:zcml="http://namespaces.zope.org/zcml">
 
   <include file="meta.zcml" package="zope.component" />
   <include file="meta.zcml" package="zope.security" />
 
   <adapter factory=".resource.AbsoluteURL" />
-  <adapter factory=".file.FileETag" />
+  <adapter factory=".file.FileETag" zcml:condition="not-installed Zope2"/>
 
   <view
       for="zope.component.interfaces.ISite"

--- a/src/zope/browserresource/configure.zcml
+++ b/src/zope/browserresource/configure.zcml
@@ -5,7 +5,7 @@
   <include file="meta.zcml" package="zope.security" />
 
   <adapter factory=".resource.AbsoluteURL" />
-  <adapter factory=".file.FileETag" zcml:condition="not-installed Zope"/>
+  <adapter factory=".file.FileETag" zcml:condition="not-installed Products.Five"/>
 
   <view
       for="zope.component.interfaces.ISite"


### PR DESCRIPTION
…ontext because Products.Five explictly regiters this adapter